### PR TITLE
feat: add touch pad for toggling display on/off

### DIFF
--- a/esp32-src/clock/main/config.c
+++ b/esp32-src/clock/main/config.c
@@ -3,14 +3,17 @@
 clock_config_t c = {
         .timezone = TIMEZONE_PARIS,
         .led_brightness_day = 15,
-        .led_brightness_night = LED_BRIGHTNESS_NOTHING,
+        .led_brightness_night = 3,
         .night_ends_hour = 8,
         .night_starts_hour = 23,
         .hour_format = FORMAT_24H,
         .thingspeak_api_key = "",
         .period_fetch_time_minutes = 10,
         .thingspeak_period_http_push_minutes = 5,
-        .bmp_period_read_minutes = 4
+        .bmp_period_read_minutes = 4,
+        .touch_enabled = 1,
+        .touch_pin = 9, // pin GPIO D32 in DEVKITV1 board
+        .touch_threshold_low = 900,
 };
 
 clock_config_t *clock_config = &c;

--- a/esp32-src/clock/main/config.h
+++ b/esp32-src/clock/main/config.h
@@ -23,6 +23,9 @@ typedef struct clock_config_t {
     int period_fetch_time_minutes;
     int thingspeak_period_http_push_minutes;
     int bmp_period_read_minutes;
+    int touch_enabled;
+    int touch_pin;
+    int touch_threshold_low;
 } clock_config_t ;
 
 extern clock_config_t *clock_config; // ugly

--- a/esp32-src/clock/main/example.c
+++ b/esp32-src/clock/main/example.c
@@ -15,6 +15,7 @@
 #include "task_watchdog.h"
 #include "task_bmp280.h"
 #include "task_thingspeak.h"
+#include "task_touch.h"
 #include "time.h"
 #include "clock.h"
 
@@ -49,6 +50,7 @@ void app_main(void){
     xTaskCreate(&watchdog_task, "watchdog_task", 5*1024, NULL, 5, NULL);
     xTaskCreate(&bmp280_task, "bmp280_task", configMINIMAL_STACK_SIZE * 8, NULL, 5, NULL);
     xTaskCreate(&thingspeak_task, "thingspeak_task", configMINIMAL_STACK_SIZE * 8, NULL, 5, NULL);
+    xTaskCreate(&touch_task, "touch_pad_read_task", 2048, NULL, 5, NULL);
 
     while (1) {
         vTaskDelay(1000 / portTICK_PERIOD_MS);

--- a/esp32-src/clock/main/task_touch.c
+++ b/esp32-src/clock/main/task_touch.c
@@ -1,0 +1,36 @@
+#include "task_touch.h"
+#include <stdio.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "driver/touch_pad.h"
+#include "esp_log.h"
+#include "config.h"
+
+#define TOUCH_THRESH_NO_USE   (0)
+#define TOUCHPAD_FILTER_TOUCH_PERIOD (10)
+
+int touch_button = 1;
+
+void touch_task(void *pvParameters) {
+    if (!clock_config->touch_enabled) {
+        while (1) {
+            vTaskDelay(1000 / portTICK_PERIOD_MS);
+        }
+    }
+
+    touch_pad_init();
+    touch_pad_set_voltage(TOUCH_HVOLT_2V7, TOUCH_LVOLT_0V5, TOUCH_HVOLT_ATTEN_1V);
+    touch_pad_config(clock_config->touch_pin, TOUCH_THRESH_NO_USE);
+    touch_pad_filter_start(TOUCHPAD_FILTER_TOUCH_PERIOD);
+
+    uint16_t touch_filter_value;
+
+    while (1) {
+        touch_pad_read_filtered(clock_config->touch_pin, &touch_filter_value);
+        if (touch_filter_value < clock_config->touch_threshold_low) {
+            touch_button = 0;
+            vTaskDelay(500 / portTICK_PERIOD_MS);
+        }
+        vTaskDelay(10 / portTICK_PERIOD_MS);
+    }
+}

--- a/esp32-src/clock/main/task_touch.h
+++ b/esp32-src/clock/main/task_touch.h
@@ -1,0 +1,6 @@
+#ifndef OVERCLOCK_TASK_TOUCH_H
+#define OVERCLOCK_TASK_TOUCH_H
+
+void touch_task(void *pvParameters);
+
+#endif //OVERCLOCK_TASK_TOUCH_H


### PR DESCRIPTION
This PR adds a touchpad to toggle on/off the display. The capacitive sensor is plugged into GPIO D32.


![pr](https://user-images.githubusercontent.com/1812795/184493014-e8bb7c2e-076d-4afc-8ab8-7e1b94c5b3d9.gif)

