### PR TITLE
feat: plug fault-tolerant interval intersection

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ make monitor # exit with Ctrl + ]
 
 ## TODO
 
-- [ ] kerning
+- [X] kerning
 - [ ] fw update
-- [ ] time consensus based on interval intersection
+- [X] time consensus based on interval intersection
 - [ ] fall back to NTP?
 - [ ] better story for provisioning secrets
 - [ ] better story for configuration?

--- a/esp32-src/clock/main/clock.c
+++ b/esp32-src/clock/main/clock.c
@@ -29,6 +29,10 @@ static uint64_t get_local_midp(void) {
     return local_midp;
 }
 
+uint64_t clock_get_time_uint64(void) {
+    return get_local_midp() + (vrt_time_last_updated - vrt_local_last_updated)*1e6;
+}
+
 static int64_t diff(uint64_t a, uint64_t b) {
     return (a>b) ? (a-b) : -(b-a);
 }

--- a/esp32-src/clock/main/clock.h
+++ b/esp32-src/clock/main/clock.h
@@ -1,6 +1,7 @@
 #ifndef CLOCK_CLOCK_H
 #define CLOCK_CLOCK_H
 
+uint64_t clock_get_time_uint64(void);
 time_t clock_get_time(void);
 void clock_add(uint64_t midpoint);
 bool clock_is_synched(void);

--- a/esp32-src/clock/main/fti.c
+++ b/esp32-src/clock/main/fti.c
@@ -6,14 +6,14 @@
 
 #include "fti.h"
 
-fti_ret_t fti_add_sample(fti_ctx_t *ctx, uint64_t left, uint64_t right) {
+fti_ret_t fti_add_sample(fti_ctx_t *ctx, fti_sample_t left, fti_sample_t right) {
     ctx->samples_left [ctx->size] = left;
     ctx->samples_right[ctx->size] = right;
     ctx->size++;
     return FTI_SUCCESS;
 }
 
-fti_ret_t fti_get_intersection(fti_ctx_t *ctx, uint64_t *out_left, uint64_t *out_right) {
+fti_ret_t fti_get_intersection(fti_ctx_t *ctx, fti_sample_t *out_left, fti_sample_t *out_right) {
     if (ctx->faulty >= ctx->size) {
         return FTI_ERROR_INVALID_FAULTY;
     }
@@ -24,9 +24,9 @@ fti_ret_t fti_get_intersection(fti_ctx_t *ctx, uint64_t *out_left, uint64_t *out
     return FTI_SUCCESS;
 }
 
-void fti_insertion_sort(uint32_t *a, const size_t n, fti_sortdir_t sd) {
+void fti_insertion_sort(fti_sample_t *a, const size_t n, fti_sortdir_t sd) {
     for (size_t i=1; i < n; ++i) {
-        uint32_t key = a[i];
+        fti_sample_t key = a[i];
         size_t j = i;
         while ((j > 0) && ((sd == FTI_SORT_ASC) ? (key < a[j - 1]) : (key >= a[j - 1]))) {
             a[j] = a[j - 1];

--- a/esp32-src/clock/main/fti.h
+++ b/esp32-src/clock/main/fti.h
@@ -10,9 +10,11 @@
 #include <stddef.h>
 #include <stdint.h>
 
+typedef uint64_t fti_sample_t;
+
 typedef struct fti_ctx_t {
-    uint32_t *samples_left;
-    uint32_t *samples_right;
+    fti_sample_t *samples_left;
+    fti_sample_t *samples_right;
     uint32_t size;
     uint32_t faulty;
 } fti_ctx_t;
@@ -32,10 +34,10 @@ typedef enum {
 extern "C" {
 #endif
 
-fti_ret_t fti_add_sample(fti_ctx_t *ctx, uint64_t left, uint64_t right);
-fti_ret_t fti_get_intersection(fti_ctx_t *ctx, uint64_t *out_left, uint64_t *out_right);
+fti_ret_t fti_add_sample(fti_ctx_t *ctx, fti_sample_t left, fti_sample_t right);
+fti_ret_t fti_get_intersection(fti_ctx_t *ctx, fti_sample_t *out_left, fti_sample_t *out_right);
 
-void fti_insertion_sort(uint32_t *a, const size_t n, fti_sortdir_t sd);
+void fti_insertion_sort(fti_sample_t *a, const size_t n, fti_sortdir_t sd);
 
 #ifdef __cplusplus
 }

--- a/esp32-src/clock/main/tests/test_fti.cc
+++ b/esp32-src/clock/main/tests/test_fti.cc
@@ -4,26 +4,26 @@
 #include "../fti.h"
 
 TEST_CASE("test insertion sort") {
-    uint32_t a[4] = {4,2,3,1};
+    fti_sample_t a[4] = {4,2,3,1};
     fti_insertion_sort(a, 4, FTI_SORT_ASC);
     REQUIRE(byte_vec_t(a, a+4) == byte_vec_t{1, 2, 3, 4});
 
-    uint32_t b[4] = {4,2,3,1};
+    fti_sample_t b[4] = {4,2,3,1};
     fti_insertion_sort(b, 4, FTI_SORT_DESC);
     REQUIRE(byte_vec_t(b, b+4) == byte_vec_t{4,3,2,1});
 
-    uint32_t c[5] = {4,2,3,5,1};
+    fti_sample_t c[5] = {4,2,3,5,1};
     fti_insertion_sort(c, 5, FTI_SORT_ASC);
     REQUIRE(byte_vec_t(c, c+5) == byte_vec_t{1, 2, 3, 4, 5});
 }
 
 TEST_CASE("test fti") {
     fti_ctx_t ctx = {
-            .samples_left = (uint32_t *)calloc(6, 4),
-            .samples_right = (uint32_t *)calloc(6, 4),
+            .samples_left = (fti_sample_t *)calloc(6, sizeof(fti_sample_t)),
+            .samples_right = (fti_sample_t *)calloc(6, sizeof(fti_sample_t)),
             .faulty = 1,
     };
-    uint64_t left, right;
+    fti_sample_t left, right;
     fti_add_sample(&ctx, 1, 10);
     fti_add_sample(&ctx, 2, 20);
     fti_add_sample(&ctx, 3, 30);

--- a/esp32-src/clock/main/vrt_quorum.c
+++ b/esp32-src/clock/main/vrt_quorum.c
@@ -21,6 +21,7 @@
 #include "clock.h"
 
 #include "vrt_quorum.h"
+#include "fti.h"
 
 static const char *TAG = "vrt_quorum";
 
@@ -81,7 +82,7 @@ static vrt_ret_t vrt_one_server(char *hostname, char *ip_override, int port, uin
 
         // set a timeout
         struct timeval timeout;
-        timeout.tv_sec = 3;
+        timeout.tv_sec = 10;
         timeout.tv_usec = 0;
         if (setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) < 0) {
             ESP_LOGE(TAG, "Error setting timeout");
@@ -93,7 +94,7 @@ static vrt_ret_t vrt_one_server(char *hostname, char *ip_override, int port, uin
         int len = recvfrom(sock, vrt_buffer, sizeof(vrt_buffer), 0, (struct sockaddr *) &source_addr, &socklen);
 
         if (len < 0) {
-            ESP_LOGE(TAG, "recvfrom failed: errno %d", errno);
+            ESP_LOGE(TAG, "recvfrom failed: errno %d len %d", errno, len);
             break;
         }
 
@@ -121,13 +122,15 @@ static vrt_ret_t vrt_one_server(char *hostname, char *ip_override, int port, uin
 
 // NB: this code must be updatable via firmware update.
 // we hardcode here the cloudflare server
-// https://github.com/cloudflare/roughtime/blob/master/ecosystem.json
+// recent-ish ecosystem file: https://github.com/wingel/vadarklockan/blob/main/examples/python/ecosystem.json
+// note: cloudflare's ecosystem.json is outdated
 
 typedef struct vrt_serverconf_t {
     char override_ip[128];
     char hostname[128];
     uint32_t port;
     uint8_t pk[32];
+    uint32_t pick_for_quorum;
 } vrt_serverconf_t;
 
 vrt_serverconf_t vrt_servers[] = {
@@ -151,13 +154,13 @@ vrt_serverconf_t vrt_servers[] = {
                        0xfd, 0x2f, 0x93, 0xec, 0xc3, 0x53, 0x8f, 0x1a},
         },
         {
-                .hostname = "roughtime.sandbox.google.com",
-                .override_ip = "173.194.202.158",
+                .hostname = "roughtime.int08h.com",
+                .override_ip = "35.192.98.51",
                 .port = 2002,
-                // echo etPaaIxcBMY1oUeGpwvPMCJMwlRVNxv51KK/tktoJTQ= | base64 -D | xxd -i
-                .pk = {  0x7a, 0xd3, 0xda, 0x68, 0x8c, 0x5c, 0x04, 0xc6, 0x35, 0xa1, 0x47, 0x86,
-                         0xa7, 0x0b, 0xcf, 0x30, 0x22, 0x4c, 0xc2, 0x54, 0x55, 0x37, 0x1b, 0xf9,
-                         0xd4, 0xa2, 0xbf, 0xb6, 0x4b, 0x68, 0x25, 0x34},
+                // echo AW5uAoTSTDfG5NfY1bTh08GUnOqlRb+HVhbJ3ODJvsE= | base64 -D | xxd -i
+                .pk = {  0x01, 0x6e, 0x6e, 0x02, 0x84, 0xd2, 0x4c, 0x37, 0xc6, 0xe4, 0xd7, 0xd8,
+                         0xd5, 0xb4, 0xe1, 0xd3, 0xc1, 0x94, 0x9c, 0xea, 0xa5, 0x45, 0xbf, 0x87,
+                         0x56, 0x16, 0xc9, 0xdc, 0xe0, 0xc9, 0xbe, 0xc1},
         },
         {
                 .hostname = "roughtime.cloudflare.com",
@@ -167,15 +170,47 @@ vrt_serverconf_t vrt_servers[] = {
                 .pk = {0x80, 0x3e, 0xb7, 0x85, 0x28, 0xf7, 0x49, 0xc4, 0xbe, 0xc2, 0xe3, 0x9e,
                        0x1a, 0xbb, 0x9b, 0x5e, 0x5a, 0xb7, 0xe4, 0xdd, 0x5c, 0xe4, 0xb6, 0xf2,
                        0xfd, 0x2f, 0x93, 0xec, 0xc3, 0x53, 0x8f, 0x1a},
+                .pick_for_quorum = 1,
         },
         {
-                .hostname = "roughtime.sandbox.google.com",
-                .override_ip = "",
+                .hostname = "roughtime.se",
+                .override_ip = "", // 192.36.143.134
                 .port = 2002,
-                // echo etPaaIxcBMY1oUeGpwvPMCJMwlRVNxv51KK/tktoJTQ= | base64 -D | xxd -i
-                .pk = {  0x7a, 0xd3, 0xda, 0x68, 0x8c, 0x5c, 0x04, 0xc6, 0x35, 0xa1, 0x47, 0x86,
-                         0xa7, 0x0b, 0xcf, 0x30, 0x22, 0x4c, 0xc2, 0x54, 0x55, 0x37, 0x1b, 0xf9,
-                         0xd4, 0xa2, 0xbf, 0xb6, 0x4b, 0x68, 0x25, 0x34},
+                // echo S3AzfZJ5CjSdkJ21ZJGbxqdYP/SoE8fXKY0+aicsehI= | base64 -D | xxd -i
+                .pk = {0x4b, 0x70, 0x33, 0x7d, 0x92, 0x79, 0x0a, 0x34, 0x9d, 0x90, 0x9d, 0xb5,
+                          0x64, 0x91, 0x9b, 0xc6, 0xa7, 0x58, 0x3f, 0xf4, 0xa8, 0x13, 0xc7, 0xd7,
+                          0x29, 0x8d, 0x3e, 0x6a, 0x27, 0x2c, 0x7a, 0x12},
+                .pick_for_quorum = 1,
+        },
+        {
+                .hostname = "time.txryan.com",
+                .override_ip = "", // 209.50.50.228
+                .port = 2002,
+                // echo iBVjxg/1j7y1+kQUTBYdTabxCppesU/07D4PMDJk2WA= | base64 -D | xxd -i
+                .pk = {  0x88, 0x15, 0x63, 0xc6, 0x0f, 0xf5, 0x8f, 0xbc, 0xb5, 0xfa, 0x44, 0x14,
+                         0x4c, 0x16, 0x1d, 0x4d, 0xa6, 0xf1, 0x0a, 0x9a, 0x5e, 0xb1, 0x4f, 0xf4,
+                         0xec, 0x3e, 0x0f, 0x30, 0x32, 0x64, 0xd9, 0x60},
+                .pick_for_quorum = 1,
+        },
+        {
+                .hostname = "sth1.roughtime.netnod.se",
+                .override_ip = "", // 194.58.207.198
+                .port = 2002,
+                // echo   | base64 -D | xxd -i
+                .pk = {0xf6, 0x5d, 0x49, 0x37, 0x81, 0xda, 0x90, 0x69, 0xc6, 0xe3, 0x8c, 0xb2,
+                          0xab, 0x23, 0x4d, 0x09, 0xbd, 0x07, 0x37, 0x45, 0xdf, 0xb3, 0x2b, 0x01,
+                          0x6e, 0x79, 0x7f, 0x91, 0xb6, 0x68, 0x64, 0x37},
+                .pick_for_quorum = 1,
+        },
+        {
+                .hostname = "sth2.roughtime.netnod.se",
+                .override_ip = "", // 194.58.207.199
+                .port = 2002,
+                // echo   | base64 -D | xxd -i
+                .pk = {  0x4f, 0xfc, 0x71, 0x5f, 0x81, 0x11, 0x50, 0x10, 0x0e, 0xa6, 0xde, 0xb8,
+                         0x67, 0xca, 0x61, 0x59, 0xa9, 0x8a, 0xb0, 0x04, 0x99, 0xc4, 0x9d, 0x15,
+                         0x5a, 0xe8, 0x8f, 0x9b, 0x71, 0x92, 0xff, 0xc8},
+                .pick_for_quorum = 1,
         },
         {
                 .hostname = "roughtime.int08h.com",
@@ -185,19 +220,17 @@ vrt_serverconf_t vrt_servers[] = {
                 .pk = {  0x01, 0x6e, 0x6e, 0x02, 0x84, 0xd2, 0x4c, 0x37, 0xc6, 0xe4, 0xd7, 0xd8,
                          0xd5, 0xb4, 0xe1, 0xd3, 0xc1, 0x94, 0x9c, 0xea, 0xa5, 0x45, 0xbf, 0x87,
                          0x56, 0x16, 0xc9, 0xdc, 0xe0, 0xc9, 0xbe, 0xc1},
+                .pick_for_quorum = 1,
         },
 };
 
-
-// TODO: implement marzullo algorithm
-
-vrt_ret_t vrt_quorum(void) {
+vrt_ret_t vrt_quorum_singleserver(void) {
     int ret = VRT_ERROR_BOUNDS;
     which_synched=-1;
     uint64_t out_midpoint;
     uint32_t out_radii;
     for (int i=1; i<sizeof(vrt_servers)/ sizeof(vrt_servers[0]); i++) {
-        ESP_LOGI(TAG, "Attempting to sync with %s...",vrt_servers[i].hostname );
+        ESP_LOGI(TAG, "vrt_quorum_singleserver: attempting to sync with %s...",vrt_servers[i].hostname );
         ret = vrt_one_server(vrt_servers[i].hostname,
                              vrt_servers[i].override_ip,
                              vrt_servers[i].port,
@@ -205,15 +238,124 @@ vrt_ret_t vrt_quorum(void) {
                              &out_midpoint,
                              &out_radii);
         if (ret == VRT_SUCCESS) {
-            ESP_LOGI(TAG, "parsed vrt midp: %" PRIu64 " radi: %u", out_midpoint, out_radii);
+            ESP_LOGI(TAG, "vrt_quorum_singleserver: midp: %" PRIu64 " radi: %u", out_midpoint, out_radii);
             clock_add(out_midpoint);
 
             which_synched = i;
             return ret;
         } else {
-            ESP_LOGE(TAG, "vrt_one_server failed");
+            ESP_LOGE(TAG, "vrt_quorum_singleserver: cannot parse server response");
             continue;
         }
     }
+    return ret;
+}
+
+vrt_ret_t vrt_quorum_multipleservers(void) {
+    int ret = VRT_ERROR_BOUNDS;
+
+    uint64_t first_local_midp = 0;
+
+    fti_ctx_t ctx = {
+            .samples_left = (uint64_t *)calloc(sizeof(vrt_servers)/ sizeof(vrt_servers[0]), sizeof(fti_sample_t)),
+            .samples_right = (uint64_t *)calloc(sizeof(vrt_servers)/ sizeof(vrt_servers[0]), sizeof(fti_sample_t)),
+            .faulty = 1,
+    };
+
+    for (int i=0; i<sizeof(vrt_servers)/ sizeof(vrt_servers[0]); i++) {
+        uint64_t server_midpoint;
+        uint32_t server_radii;
+        if (!vrt_servers[i].pick_for_quorum) {
+            continue;
+        }
+        ESP_LOGI(TAG, "vrt_quorum_multipleservers: attempting to sync with %s...", vrt_servers[i].hostname );
+
+        ret = vrt_one_server(vrt_servers[i].hostname,
+                             vrt_servers[i].override_ip,
+                             vrt_servers[i].port,
+                             vrt_servers[i].pk,
+                             &server_midpoint,
+                             &server_radii);
+
+        uint64_t local_midp = clock_get_time_uint64();
+        if (first_local_midp == 0) {
+            first_local_midp = local_midp;
+        }
+
+        if (ret == VRT_SUCCESS) {
+            ESP_LOGI(TAG, "vrt_quorum_multipleservers: parsed vrt midp: %" PRIu64 " radi: %u", server_midpoint, server_radii);
+            // account for delays in signature verification, etc
+            uint64_t offset = local_midp - first_local_midp;
+            if (offset > 120 * 1e6) {
+                ESP_LOGE(TAG, "vrt_quorum_multipleservers: invalid offset %" PRIu64 ", must be small", offset);
+            }
+            uint64_t left = server_midpoint - offset - server_radii;
+            uint64_t right = server_midpoint - offset + server_radii;
+            ESP_LOGI(TAG, "vrt_quorum_multipleservers: adding %" PRIu64 " %" PRIu64, left, right);
+            // check return error
+            fti_add_sample(&ctx, left, right);
+        } else {
+            ESP_LOGE(TAG, "vrt_quorum_multipleservers: cannot parse server response");
+            continue;
+        }
+    }
+
+    uint64_t quorum_left;
+    uint64_t quorum_right;
+    if (fti_get_intersection(&ctx, &quorum_left, &quorum_right) != FTI_SUCCESS) {
+        ESP_LOGE(TAG, "vrt_quorum_multipleservers: failed intersection");
+        goto exit;
+    }
+
+    if (ctx.size < 3) {
+        ESP_LOGE(TAG, "vrt_quorum_multipleservers: quorum %d is too small, not adjusting...", ctx.size);
+        goto exit;
+    }
+    ESP_LOGI(TAG, "vrt_quorum_multipleservers: size: %d ", ctx.size);
+
+    ret = VRT_SUCCESS;
+    uint64_t local_midp = clock_get_time_uint64();
+    uint64_t offset = local_midp - first_local_midp;
+    uint64_t quorum_midp = quorum_left + (quorum_right - quorum_left)/2 + offset;
+
+    if (offset > (120 * 1e6)) {
+        ESP_LOGE(TAG, "vrt_quorum_multipleservers: offset is too large %" PRIu64, offset);
+        goto exit;
+    }
+
+    uint64_t adjust = (local_midp > quorum_midp) ? (local_midp - quorum_midp) : (quorum_midp - local_midp);
+    if (adjust > (120 * 1e6)) {
+        ESP_LOGE(TAG, "vrt_quorum_multipleservers: adjust is too large "
+                      " adjust: %" PRIu64
+                       " local_midp: %" PRIu64
+                       " quorum_midp: %" PRIu64,
+                       adjust,
+                       local_midp,
+                       quorum_midp);
+        goto exit;
+    }
+
+    ESP_LOGI(TAG, "vrt_quorum_multipleservers: size: %d "
+                  " offset: %" PRIu64
+                  " adjust: %" PRIu64
+                  " quorum_left: %" PRIu64
+                  " quroum_right: %" PRIu64
+                  " quorum_midp: %" PRIu64
+                  " quorum_left: %" PRIu64
+                  " quorum_right: %" PRIu64,
+                  ctx.size,
+                  offset,
+                  adjust,
+                  quorum_left,
+                  quorum_right,
+                  quorum_midp,
+                  quorum_left,
+                  quorum_right);
+
+    clock_add(quorum_midp);
+
+    exit:
+    free(ctx.samples_left);
+    free(ctx.samples_right);
     return ret;
 }

--- a/esp32-src/clock/main/vrt_quorum.h
+++ b/esp32-src/clock/main/vrt_quorum.h
@@ -1,3 +1,5 @@
 #include "vrt.h"
 
-vrt_ret_t vrt_quorum(void);
+vrt_ret_t vrt_quorum_singleserver(void);
+vrt_ret_t vrt_quorum_multipleservers(void);
+


### PR DESCRIPTION
This PR adds minimal support for quorum-based agreement to establish time. Currently we require a minimum of 3 servers alive and can handle up to 1 server that lies about time.

Other house keeping tasks in this PR:
- clean up server list: remove google (seems defunct), add some new ones
- some new servers don't work yet since they implement a newer version, filed https://github.com/oreparaz/vroughtime/issues/13 to address
- bugfix (type confusion in `fti` module)
